### PR TITLE
Support excluding files from final squashfs image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,12 +95,7 @@
               "mountroot d 777 0 0" # TODO permissions?
             ];
             extra-args = pkgs.lib.concatMapStrings (x: " -p \"${x}\"") extras;
-            exclude-args =
-              let
-                exclude-prefix = pkgs.lib.lists.optional (exclude != []) " -wildcards -e";
-                exclude-entries = map (x: " \"${x}\"") exclude;
-              in
-                pkgs.lib.strings.concatStrings (exclude-prefix ++ exclude-entries);
+            exclude-args = pkgs.lib.optional (exclude != []) " -wildcards -e ${pkgs.lib.escapeShellArgs exclude}";
           in
           pkgs.runCommand "${name}-${arch}.AppImage"
             {


### PR DESCRIPTION
Often times the final squashfs image contains a bunch of unnecessary or unused files the appimage will not use at runtime. It is desireable to exclude those files so the appimage will be slimmer.

This commit adds support for glob-enabled file exclusions, as supported by `mksquashfs -wildcards -e ...`.