### PR TITLE
add bwrap Apprun

### DIFF
--- a/appruns/bwrap/default.nix
+++ b/appruns/bwrap/default.nix
@@ -1,7 +1,9 @@
-{ runCommand
+{ runCommand,
+  pkgsStatic
 }:
 
 runCommand "AppRun" { } ''
   mkdir $out
   cp ${./test.sh} $out/AppRun
+  cp ${pkgsStatic.bubblewrap}/bin/bwrap $out/bwrap
 ''

--- a/appruns/bwrap/default.nix
+++ b/appruns/bwrap/default.nix
@@ -1,0 +1,7 @@
+{ runCommand
+}:
+
+runCommand "AppRun" { } ''
+  mkdir $out
+  cp ${./test.sh} $out/AppRun
+''

--- a/appruns/bwrap/test.sh
+++ b/appruns/bwrap/test.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 LOCATION="$(dirname -- "$(readlink -f "${BASH_SOURCE}")")"
-bwrap $(ls / | grep -v -E "dev|proc" | xargs -I % echo --bind /% /% | tr '\n' ' ') --dev-bind /dev /dev --proc /proc --ro-bind $LOCATION/nix /nix $(readlink $LOCATION/entrypoint) $@
+$LOCATION/bwrap $(ls / | grep -v -E "dev|proc" | xargs -I % echo --bind /% /% | tr '\n' ' ') --dev-bind /dev /dev --proc /proc --ro-bind $LOCATION/nix /nix $(readlink $LOCATION/entrypoint) $@

--- a/appruns/bwrap/test.sh
+++ b/appruns/bwrap/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+LOCATION="$(dirname -- "$(readlink -f "${BASH_SOURCE}")")"
+bwrap $(ls / | grep -v -E "dev|proc" | xargs -I % echo --bind /% /% | tr '\n' ' ') --dev-bind /dev /dev --proc /proc --ro-bind $LOCATION/nix /nix $(readlink $LOCATION/entrypoint) $@

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
         # appruns contain an AppRun executable that does setup and launches entrypoint
         packages.appimage-appruns = {
           userns-chroot = pkgs.callPackage ./appruns/userns-chroot { };
+          bwrap = pkgs.callPackage ./appruns/bwrap { };
         };
 
         lib.mkAppImage = pkgs.callPackage ./mkAppImage.nix {


### PR DESCRIPTION
This is a try to create a new Apprun using bwrap and without doing chroot.
**It needs bubblewrap to be installed on the machine that will run the AppImage.**

It allows all files from the root folder to be visible inside the appimage. For example, vim can now load plugins or run LSP server installed outside the AppImage.

However, if /nix already exist on the computer, it will be replaced inside the bwrap sandbox by the /nix of the AppImage. So it's not meant to be used in nixos or any computer with nix already installed.

I didn't tested, but normally bwrap don't prevent to create user namespaces (related to #10 ), so you should be able to run chromium or any electron apps. However you may still need nixGL for opengl related things.

The apprun is written in bash and can probably be improved, I'm open to suggestions and thank you for your incredible project !