### PR TITLE
Update inputs (nixpkgs, flake-compat, etc)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725103162,
-        "narHash": "sha256-Ym04C5+qovuQDYL/rKWSR+WESseQBbNAe5DsXNx5trY=",
+        "lastModified": 1745997950,
+        "narHash": "sha256-FklMkU+bPPx0L3i6pdrw65js05VO9He3DTeKguX9GQY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "12228ff1752d7b7624a54e9c1af4b222b3c1073b",
+        "rev": "cf3ffa5d140899101f1deb3f4d16b1a1aa2de849",
         "type": "github"
       },
       "original": {

--- a/runtimes/appimage-type2-runtime/default.nix
+++ b/runtimes/appimage-type2-runtime/default.nix
@@ -5,7 +5,7 @@
 , squashfuse
 , zstd
 , zlib
-, lzma
+, xz
 , lz4
 , lzo
 }:
@@ -26,7 +26,7 @@ let
   });
 
   squashfuse' = (squashfuse.override {
-    fuse = fuse3';
+    fuse3 = fuse3';
   }).overrideAttrs (old: {
     postInstall = (old.postInstall or "") + ''
       cp *.h -t $out/include/squashfuse/
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
     squashfuse'
     zstd
     zlib
-    lzma
+    xz
     lz4
     lzo
   ];

--- a/runtimes/appimagecrafters/basename.patch
+++ b/runtimes/appimagecrafters/basename.patch
@@ -1,0 +1,15 @@
+diff --git a/src/main.c b/src/main.c
+index 82b4241..cd003bf 100644
+--- a/src/main.c
++++ b/src/main.c
+@@ -40,6 +40,7 @@ extern dev_t sqfs_makedev(int maj, int min);
+ 
+ extern int sqfs_opt_proc(void* data, const char* arg, int key, struct fuse_args* outargs);
+ 
++#include <libgen.h>
+ #include <limits.h>
+ #include <stdlib.h>
+ #include <sys/types.h>
+-- 
+2.49.0
+


### PR DESCRIPTION
This PR updates the Nix flake inputs, and updates the two runtimes so that they compile.

Fixes #23

I tested it with:

commandline app:

`$ nix bundle --bundler <LOCAL CLONE of nix-appimage> nixpkgs#mpw`

and

GUI app:

`$ nix bundle --bundler <LOCAL CLONE of nix-appimage> nixpkgs#pcmanfm`

Both applications worked on NixOS and on a Fedora distrobox.