### PR TITLE
Best-effort copying in of .desktop file and icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,8 @@ OpenGL apps not being able to run on non-NixOS systems is a **known problem**, s
 You'll need to use something like [nixGL](https://github.com/guibou/nixGL).
 Addressing this problem outright is _out of scope_ for this project, however PRs to integrate solutions (e.g. nixGL) are welcome.
 
-Additionally, the produced file isn't a _fully_ conforming AppImage.
-For example, it's missing the relevant .desktop file and icons -- this doesn't affect the running of bundled apps in any way, but might cause issues with showing up correctly in application launchers (e.g. rofi).
-Please open an issue if this is something you want.
+Additionally, we only make a best-effort attempt to copy in the relevant .desktop files and icons, so they may not be present.
+This doesn't affect the running of bundled apps, but might cause issues with showing up correctly in application launchers (e.g. rofi).
 
 The current implementation also has some limitations:
 

--- a/extra-files.sh
+++ b/extra-files.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+program=$1
+mkdir extras
+
+# get the derivation's root directory
+
+IFS=/ read -r _ nix store hash rest <<EOF
+$program
+EOF
+
+if [ "$nix" != nix ] || [ "$store" != store ]; then
+	echo "entrypoint '${program}' is not in the nix store" >&2
+	exit 1
+fi
+
+drv="/nix/store/$hash"
+
+# find desktop file
+
+desktop=
+
+# try find one whose Exec= matches $program
+for d in "$drv/share/applications/"*.desktop; do
+	if ! [ -e "$d" ]; then
+		# if we don't match any files then it's whatever
+		break
+	fi
+
+	if sed -nEe '/^Exec=/{ s/^Exec= *([^ ]*).*$/\1/; s#.*/##; p }' "$d" |
+		grep --fixed-strings --line-regexp --quiet "$(basename "$program")"
+	then
+		if [ -z "$desktop" ]; then
+			desktop=$d
+		else
+			echo "multiple .desktop entries found; giving up" >&2
+			exit
+		fi
+	fi
+done
+
+if [ -z "$desktop" ]; then
+	echo "no .desktop found; giving up" >&2
+	exit
+fi
+
+# copy desktop file and icons
+
+cp -L "$desktop" extras/
+if [ -e "$drv/share/icons/hicolor" ]; then
+	mkdir -p extras/usr/share/icons
+	cp -Lr --no-preserve=all "$drv/share/icons/hicolor" extras/usr/share/icons
+fi
+
+# create DirIcon
+
+grep ^Icon= "$desktop" | while IFS="=" read -r _ icon; do
+	for size in 128x128 64x64 scalable; do
+		for f in "${drv}/share/icons/hicolor/$size/apps/${icon}".*; do
+			[ -e "$f" ] || continue
+
+			# .DirIcon SHOULD be a 256x256 PNG, and the app could have non-PNG
+			# icons, so ideally we'd use a tool like imagemagick to create it. But that's a big dependency, and this is close enough?
+
+			cp -Lr --no-preserve=all "$f" extras/.DirIcon
+			exit
+		done
+	done
+done

--- a/extra-files.sh
+++ b/extra-files.sh
@@ -56,7 +56,7 @@ fi
 # create DirIcon
 
 grep ^Icon= "$desktop" | while IFS="=" read -r _ icon; do
-	for size in 128x128 64x64 scalable; do
+	for size in 256x256 128x128 64x64 scalable; do
 		for f in "${drv}/share/icons/hicolor/$size/apps/${icon}".*; do
 			[ -e "$f" ] || continue
 

--- a/mkAppImage.nix
+++ b/mkAppImage.nix
@@ -55,12 +55,16 @@ let
 in
 runCommand name
 {
-  nativeBuildInputs = [ squashfsTools ];
+  nativeBuildInputs = [
+    squashfsTools
+  ];
 } ''
   if ! test -x ${program}; then
     echo "entrypoint '${program}' is not executable"
     exit 1
   fi
+
+  ${./extra-files.sh} ${program}
 
   mksquashfs ${builtins.concatStringsSep " " ([
     # first run of mksquashfs copies the nix/store closure and additional files
@@ -79,7 +83,8 @@ runCommand name
   mksquashfs ${builtins.concatStringsSep " " ([
     # second run of mksquashfs adds the apprun
     # no -no-strip since we *do* want to strip leading dirs now
-    "${mkappimage-apprun}"
+    "${mkappimage-apprun}/*"
+    "$(find extras -mindepth 1 -maxdepth 1)" # to include .DirIcon
     "$out"
     "-no-recovery" # i don't know what a recovery file is but it gives "No such file or directory"
   ] ++ commonArgs)}


### PR DESCRIPTION
Try to copy in the `.desktop` files and other icons from the derivation, as specified by https://github.com/AppImage/AppImageSpec/blob/ce1910e6443357e3406a40d458f78ba3f34293b8/draft.md#the-filesystem-image

Notably, `.DirIcon` most likely won't be a 256x256 PNG, but that requirement's a SHOULD not a MUST.

Closes #18 